### PR TITLE
Bundle CSS fix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,1 +1,1 @@
-@import "../node_modules/leaflet/dist/leaflet.css";
+@import url("node_modules/leaflet/dist/leaflet.css");

--- a/css/style.css
+++ b/css/style.css
@@ -1,1 +1,1 @@
-@import url("node_modules/leaflet/dist/leaflet.css");
+/* Place styles here which should be included in the map bundle */

--- a/js/pokemap.js
+++ b/js/pokemap.js
@@ -10,6 +10,7 @@ require('leaflet.locatecontrol');
 
 // Include stylesheets
 require('../css/style.css');
+require('leaflet/dist/leaflet.css');
 
 var mymap = null;
 var apiURL={};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "browserify js/pokemap.js -o pokemap.bundle.js -t es6ify -t browserify-css --standalone PokeMap"
+    "postinstall": "browserify js/pokemap.js -o pokemap.bundle.js -t es6ify -t browserify-css -g browserify-css --standalone PokeMap"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It turns out that bundling the CSS won't work if I install your package via `npm install` because the css file cannot be found. This tiny change should fix this.
